### PR TITLE
fix: Validado fecha recibo pago inscripcion

### DIFF
--- a/controllers/admision.go
+++ b/controllers/admision.go
@@ -1223,7 +1223,7 @@ func (c *AdmisionController) GetListaAspirantesPor() {
 		switch params[tipo_lista].valor {
 		case 1:
 			var inscripcion1 []map[string]interface{}
-			errInscripcion1 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:5,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion1)
+			errInscripcion1 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:5,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc&limit=0", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion1)
 			if errInscripcion1 == nil && fmt.Sprintf("%v", inscripcion1) != "[map[]]" {
 				for _, inscrip1 := range inscripcion1 {
 					var datoIdentif1 []map[string]interface{}
@@ -1239,7 +1239,7 @@ func (c *AdmisionController) GetListaAspirantesPor() {
 				}
 			}
 			var inscripcion2 []map[string]interface{}
-			errInscripcion2 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:2,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion2)
+			errInscripcion2 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:2,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc&limit=0", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion2)
 			if errInscripcion2 == nil && fmt.Sprintf("%v", inscripcion2) != "[map[]]" {
 				for _, inscrip2 := range inscripcion2 {
 					var datoIdentif2 []map[string]interface{}
@@ -1257,7 +1257,7 @@ func (c *AdmisionController) GetListaAspirantesPor() {
 
 		case 2:
 			var inscripcion1 []map[string]interface{}
-			errInscripcion1 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:5,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion1)
+			errInscripcion1 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:5,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc&limit=0", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion1)
 			if errInscripcion1 == nil && fmt.Sprintf("%v", inscripcion1) != "[map[]]" {
 				for _, inscrip1 := range inscripcion1 {
 					var datoIdentif1 []map[string]interface{}
@@ -1271,7 +1271,7 @@ func (c *AdmisionController) GetListaAspirantesPor() {
 				}
 			}
 			var inscripcion2 []map[string]interface{}
-			errInscripcion2 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:2,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion2)
+			errInscripcion2 := request.GetJson("http://"+beego.AppConfig.String("InscripcionService")+fmt.Sprintf("inscripcion?query=EstadoInscripcionId__Id:2,ProgramaAcademicoId:%v,PeriodoId:%v&sortby=Id&order=asc&limit=0", params[id_proyecto].valor, params[id_periodo].valor), &inscripcion2)
 			if errInscripcion2 == nil && fmt.Sprintf("%v", inscripcion2) != "[map[]]" {
 				for _, inscrip2 := range inscripcion2 {
 					var datoIdentif2 []map[string]interface{}


### PR DESCRIPTION
- Se ajusta la manera en que se verifica la fecha límite de pago de recibo de inscripción, ahora el flujo es más simple y claro.
  1. Consulta la fecha límite del recibo _(fecha pago extraordinario)_
  2. Se ajusta a formato preestablecido y se convierte en tipo time.
  3. Se consulta la fecha actual, se ajusta a formato preestablecido y se convierte a tipo time.
  4. Todo está en timezone Bogota
  5. Se añade un día a la fecha límite para tener en cuenta las horas del día actual como válido para pago. pasa que "2022-12-04".Before("2022-12-04") retorna como falso, por tal motivo se suma un día.. eso permite tambien que `"2022-12-04T23:59:59"` sea válido si la fecha límite es `"2022-12-04-T00:00:00"`
  6. CLARO, TENER EN CUENTA SE HACE PORQUE LA FECHA DEL RECIBO SE ESTÁ GUARDANDO APENAS EMPIEZA EL DÍA.
- Se corrige limit en GetListaAspirantesPor(), hacía falta en 2 situaciones.