### PR TITLE
hotfix: Ajuste tamaño digitos codigo barras

### DIFF
--- a/controllers/generar_recibo.go
+++ b/controllers/generar_recibo.go
@@ -645,7 +645,7 @@ func generarCodigoBarras(pdf *gofpdf.Fpdf, datos map[string]interface{}) *gofpdf
 	}
 
 	costo := fmt.Sprintf("%.f", datos["ValorDerecho"].(float64))
-	for len(costo) < 12 {
+	for len(costo) < 10 {
 		costo = "0" + costo
 	}
 


### PR DESCRIPTION
- Se corrige el tamaño la cantidad de dígitos de costo, antes 12 ahora 10.