### PR TITLE
feat: udistrital/sga_cliente#1238 add controller get_time_bogota

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -136,7 +136,7 @@ steps:
     - push
 
 - name: update_aws_ecs
-  image: golang:1.9
+  image: golang:1.15
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ swagger/images/
 swagger/lang/
 swagger/lib/
 sga_mid.exe
+go.mod
+go.sum

--- a/controllers/time_bog.go
+++ b/controllers/time_bog.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"time"
+
+	"github.com/astaxie/beego"
+)
+
+// Time_bogController operations for Time_bog
+type Time_bogController struct {
+	beego.Controller
+}
+
+// URLMapping ...
+func (c *Time_bogController) URLMapping() {
+	c.Mapping("GetTimeBog", c.GetTimeBog)
+}
+
+// GetTimeBog ...
+// @Title GetTimeBog
+// @Description get Time_bog
+// @Success 200 {object} models.Time_bog
+// @Failure 500 something bad happened
+// @router / [get]
+func (c *Time_bogController) GetTimeBog() {
+	what_time_is_it := time.Now()
+	inUTC, _ := time.LoadLocation("UTC")
+	inBog, _ := time.LoadLocation("America/Bogota")
+	data := map[string]interface{}{
+		"UNIX": what_time_is_it.Unix() * 1000,                  // Unix timestamp fixed to seconds represeted in milliseconds
+		"UTC":  what_time_is_it.In(inUTC).Format(time.RFC3339), // UTC timestamp fixed to seconds
+		"BOG":  what_time_is_it.In(inBog).Format(time.RFC3339), // BOG timestamp fixed to seconds
+	}
+	c.Ctx.Output.SetStatus(200)
+	c.Data["json"] = map[string]interface{}{"Success": true, "Status": "200", "Message": "Query successful", "Data": data}
+	c.ServeJSON()
+}

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -1357,6 +1357,15 @@ func init() {
             Filters: nil,
             Params: nil})
 
+    beego.GlobalControllerRouter["github.com/udistrital/sga_mid/controllers:Time_bogController"] = append(beego.GlobalControllerRouter["github.com/udistrital/sga_mid/controllers:Time_bogController"],
+        beego.ControllerComments{
+            Method: "GetTimeBog",
+            Router: "/",
+            AllowHTTPMethods: []string{"get"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
     beego.GlobalControllerRouter["github.com/udistrital/sga_mid/controllers:Transferencia_reingresoController"] = append(beego.GlobalControllerRouter["github.com/udistrital/sga_mid/controllers:Transferencia_reingresoController"],
         beego.ControllerComments{
             Method: "PostSolicitud",

--- a/routers/router.go
+++ b/routers/router.go
@@ -163,6 +163,11 @@ func init() {
 				&controllers.NotasController{},
 			),
 		),
+		beego.NSNamespace("/time_bog",
+			beego.NSInclude(
+				&controllers.Time_bogController{},
+			),
+		),
 	)
 	beego.AddNamespace(ns)
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4432,6 +4432,26 @@
                 }
             }
         },
+        "/time_bog/": {
+            "get": {
+                "tags": [
+                    "time_bog"
+                ],
+                "description": "get Time_bog",
+                "operationId": "Time_bogController.GetTimeBog",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/models.Time_bog"
+                        }
+                    },
+                    "500": {
+                        "description": "something bad happened"
+                    }
+                }
+            }
+        },
         "/transferencia/": {
             "post": {
                 "tags": [
@@ -4737,6 +4757,10 @@
             "title": "Practicas_academicas",
             "type": "object"
         },
+        "models.Time_bog": {
+            "title": "Time_bog",
+            "type": "object"
+        },
         "models.Transferencia_reingreso": {
             "title": "Transferencia_reingreso",
             "type": "object"
@@ -4838,6 +4862,10 @@
         {
             "name": "notas",
             "description": "NotasController operations for Notas\n"
+        },
+        {
+            "name": "time_bog",
+            "description": "Time_bogController operations for Time_bog\n"
         }
     ]
 }

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -2914,6 +2914,19 @@ paths:
           description: '{}'
         "404":
           description: not found resource
+  /time_bog/:
+    get:
+      tags:
+      - time_bog
+      description: get Time_bog
+      operationId: Time_bogController.GetTimeBog
+      responses:
+        "200":
+          description: ""
+          schema:
+            $ref: '#/definitions/models.Time_bog'
+        "500":
+          description: something bad happened
   /transferencia/:
     post:
       tags:
@@ -3118,6 +3131,9 @@ definitions:
   models.Practicas_academicas:
     title: Practicas_academicas
     type: object
+  models.Time_bog:
+    title: Time_bog
+    type: object
   models.Transferencia_reingreso:
     title: Transferencia_reingreso
     type: object
@@ -3191,3 +3207,6 @@ tags:
 - name: notas
   description: |
     NotasController operations for Notas
+- name: time_bog
+  description: |
+    Time_bogController operations for Time_bog


### PR DESCRIPTION
- https://github.com/udistrital/sga_cliente/issues/1238
- Se crea controlador para traer la hora real de bogotá.
  - Retorna en UTC, UNIX y TimeZone America/Bogota, con precisión maxima de segundos.
- Consulta [GET] en path: `v1/time_bog`
- Requiere Update de Swagger

- **Otros**:
  - Se Actualiza versión de golang a 1.15 en step `update_aws_ecs`
  - Se añade ignore de go.mod y go.sum
  - Se borra sga_mid.exe, ya esta en gitignore pero el repo seguía cargado