### PR TITLE
hotfix: generacion de comprobantes de inscripcion

### DIFF
--- a/controllers/generar_recibo.go
+++ b/controllers/generar_recibo.go
@@ -163,7 +163,7 @@ func (c *GenerarReciboController) PostGenerarComprobanteInscripcion() {
 							"FileName":    "Comprobante_inscripcion_" + data["INSCRIPCION"].(map[string]interface{})["nombrePrograma"].(string),
 							"Base64File":  encodedFile,
 						})
-						utils.SendNotificationInscripcionComprobante(dataEmail, data["ASPIRANTE"].(map[string]interface{})["correo"].(string), attachments)
+						// utils.SendNotificationInscripcionComprobante(dataEmail, data["ASPIRANTE"].(map[string]interface{})["correo"].(string), attachments)
 					}
 
 				} else {


### PR DESCRIPTION
se inhabilita servicio de envio de notificaciones para continuar con la generacion del pdf del comprobante